### PR TITLE
Bugfix: nullish coalescing requires WebPack v5...

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chainweb",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Javascript bindings for the Kadena Chainweb API",
   "keywords": [
     "chainweb",

--- a/src/chainweb.js
+++ b/src/chainweb.js
@@ -44,12 +44,14 @@ class ResponseError extends Error {
  */
 const retryFetch = async (retryOptions, fetchAction) => {
 
+    // set default retryOptions, with any passed-in retryOptions overriding the defaults
     retryOptions = {
-        onFailedAttempt: retryOptions?.onFailedAttempt ?? (x => console.log("failed fetch attempt:", x.message)),
-        retries: retryOptions?.retries ?? 2,
-        minTimeout: retryOptions?.minTimeout ?? 500,
-        randomize: retryOptions?.randomize ?? true,
-        retry404: retryOptions?.retry404 ?? false,
+        onFailedAttempt: (x => console.log("failed fetch attempt:", x.message)),
+        retries: 2,
+        minTimeout: 500,
+        randomize: true,
+        retry404: false,
+        ...retryOptions
     };
 
     const retry404 = retryOptions.retry404;
@@ -243,7 +245,7 @@ const cutPeers = async (network, host, retryOptions) => {
 const branchPage = async (chainId, upper, lower, minHeight, maxHeight, n, next, format, network, host, retryOptions) => {
 
     /* Format and Accept header value */
-    format = format ?? 'json';
+    format = format ? format : 'json';
     var accept = "";
     switch (format) {
         case 'json': accept = 'application/json;blockheader-encoding=object'; break;
@@ -355,7 +357,7 @@ const currentBranch = async (chainId, start, end, n, format, network, host) => {
  */
 const payloads = async (chainId, hashes, format, network, host, retryOptions) => {
 
-    format = format ?? 'json';
+    format = format ? format : 'json';
 
     const url = chainUrl(chainId, network, host, `payload/outputs/batch`);
 
@@ -837,7 +839,7 @@ const filterEvents = (blocks) => {
     return blocks
         .filter(x => x.payload.transactions.length > 0)
         .flatMap(x => x.payload.transactions.flatMap(y => {
-            let es = y.output.events ?? [];
+            let es = y.output.events ? y.output.events : [];
             es.forEach(e => e.height = x.header.height);
             return es;
         }));
@@ -1008,4 +1010,5 @@ module.exports = {
         cutPeerPage: cutPeerPage,
     }
 };
+
 


### PR DESCRIPTION
```
./node_modules/chainweb/src/chainweb.js 56:34
Module parse failed: Unexpected token (56:34)
File was processed with these loaders:
 * ./node_modules/react-scripts/node_modules/babel-loader/lib/index.js
You may need an additional loader to handle the result of these loaders.
| const retryFetch = async (retryOptions, fetchAction) => {
|   retryOptions = {
>     onFailedAttempt: retryOptions?.onFailedAttempt ?? (x => console.log("failed fetch attempt:", x.message)),
|     retries: retryOptions?.retries ?? 2,
|     minTimeout: retryOptions?.minTimeout ?? 500,
```

... which requires actually having to build a full webpack config, which is an utter nightmare. This is caused by webpack no longer polyfilling core node libs in v5. Instead of requiring users to (and me) to fully embrace the darkness of webpack, I think it's just easier to make it backward compatible.

Also, the use of the spread operator `...` to override defaults for object keys is idiomatic JS.