### PR TITLE
fixing incompat with webpack v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chainweb",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Javascript bindings for the Kadena Chainweb API",
   "keywords": [
     "chainweb",

--- a/src/chainweb.js
+++ b/src/chainweb.js
@@ -434,7 +434,7 @@ const chainUpdates = (depth, chainIds, callback, network, host) => {
     let bs = {};
     chainIds.forEach(x => bs[x] = new HeaderBuffer(depth, callback));
     return headerUpdates(
-        hdr => bs[hdr.header.chainId]?.add(hdr),
+        hdr => (bs[hdr.header.chainId].add === null || bs[hdr.header.chainId].add === undefined) ? undefined : bs[hdr.header.chainId].add(hdr),
         network,
         host
     );


### PR DESCRIPTION
Apparently webpack v4 has a problem with optional chaining... even though it's been around forever. 

From the docs, this change should have no impact on behavior: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining#description

Signed-off-by: Will Martino <1953196+buckie@users.noreply.github.com>