### PR TITLE
Pass network details to header.blockHash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/*

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chainweb",
-  "version": "2.0.0",
+  "version": "2.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "chainweb",
-      "version": "2.0.0",
+      "version": "2.0.3",
       "license": "MIT",
       "dependencies": {
         "base64-url": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chainweb",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Javascript bindings for the Kadena Chainweb API",
   "keywords": [
     "chainweb",

--- a/src/chainweb.js
+++ b/src/chainweb.js
@@ -434,7 +434,7 @@ const chainUpdates = (depth, chainIds, callback, network, host) => {
     let bs = {};
     chainIds.forEach(x => bs[x] = new HeaderBuffer(depth, callback));
     return headerUpdates(
-        hdr => (bs[hdr.header.chainId].add === null || bs[hdr.header.chainId].add === undefined) ? undefined : bs[hdr.header.chainId].add(hdr),
+        hdr => (bs[hdr.header.chainId] == null || bs[hdr.header.chainId].add == null) ? undefined : bs[hdr.header.chainId].add(hdr),
         network,
         host
     );
@@ -542,7 +542,7 @@ const headerStreamSince = (start, depth, chainId, callback, network, host) => {
  * @alias module:chainweb.header.hash
  */
 const headerByBlockHash = async (chainId, hash, network, host) => {
-    const x = await branch(chainId, [hash], [], null, null, 1);
+    const x = await branch(chainId, [hash], [], null, null, 1, null, network, host, null);
     return x[0];
 }
 
@@ -1010,5 +1010,3 @@ module.exports = {
         cutPeerPage: cutPeerPage,
     }
 };
-
-

--- a/test.js
+++ b/test.js
@@ -4,6 +4,7 @@ const HeaderBuffer = require('./src/HeaderBuffer');
 /* ************************************************************************** */
 /* Test settings */
 
+jest.setTimeout(25000);
 const debug = false;
 // const streamTest = test.concurrent.skip;
 const streamTest = test.concurrent;
@@ -42,7 +43,7 @@ describe("retry", () => {
 
 describe("Cuts", () => {
     test("peers", async () => {
-        const r = await chainweb.cut.peers();
+        const r = await chainweb.cut.peers("mainnet01", "https://us-e1.chainweb.com");
         logg("Cut Peers:", r);
         expect(r).toBeTruthy();
         expect(r.length).toBeGreaterThan(0);
@@ -419,4 +420,3 @@ function testHeaderBuffer () {
 test("HeaderBuffer", () => {
     expect(testHeaderBuffer()).toBe(true);
 });
-


### PR DESCRIPTION
- pass network, host info to `header.blockHash` 
- change null check in `chainUpdates` - causes error in test
- upgrades version to 2.0.3