### PR TITLE
Fix missing variables declaration

### DIFF
--- a/src/chainweb.js
+++ b/src/chainweb.js
@@ -149,7 +149,7 @@ const pageIterator = async function * (query, n) {
 const reversePages = async (query, n) => {
     const iter = pageIterator(query, n);
     let ps = [];
-    for await (p of iter) {
+    for await (const p of iter) {
         ps.unshift(p.reverse());
     }
     return ps.flat();

--- a/src/chainweb.js
+++ b/src/chainweb.js
@@ -142,17 +142,6 @@ const pageIterator = async function * (query, n) {
     } while (next && (n ? c < n : true));
 }
 
-/** Yields flattened pages, i.e. individual page items are yielded.
- */
-const pageItemIterator = async function * (query, n) {
-    const iter = pageIterator(query, n);
-    for await (p of iter) {
-        for await (i of p) {
-            yield p;
-        }
-    }
-}
-
 /* Yields items from pages in reverse order.
  *
  * WARNING: This awaits and buffers all pages before returning.


### PR DESCRIPTION
Undeclared variables are causing the package to fail in strict mode when calling `reversePages`, which in turn happens in pact-lang-api as well.